### PR TITLE
Upgrade to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,14 +106,20 @@ jobs:
         id: registries
         shell: bash
         env:
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKERHUB_REPOSITORY: ${{ vars.DOCKERHUB_REPOSITORY }}
         run: |
           set -euo pipefail
 
+          ghcr_image="ghcr.io/${{ github.repository_owner }}/${REPOSITORY_NAME}"
+          echo "ghcr_image=${ghcr_image}" >> "$GITHUB_OUTPUT"
+
           if [ -n "${DOCKERHUB_USERNAME:-}" ] && [ -n "${DOCKERHUB_TOKEN:-}" ]; then
+            dockerhub_repo="${DOCKERHUB_REPOSITORY:-${DOCKERHUB_USERNAME}/${REPOSITORY_NAME}}"
             echo "dockerhub_enabled=true" >> "$GITHUB_OUTPUT"
-            echo "dockerhub_image=${DOCKERHUB_USERNAME}/komodo-periphery-sops-age" >> "$GITHUB_OUTPUT"
+            echo "dockerhub_image=${dockerhub_repo}" >> "$GITHUB_OUTPUT"
           else
             echo "dockerhub_enabled=false" >> "$GITHUB_OUTPUT"
             echo "dockerhub_image=" >> "$GITHUB_OUTPUT"
@@ -128,8 +134,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          IMAGE="ghcr.io/${{ github.repository_owner }}/komodo-periphery-sops-age:latest"
-          BASE="ghcr.io/moghtech/komodo-periphery:latest"
+          BASE="ghcr.io/moghtech/komodo-periphery:2"
+          IMAGE="${{ steps.registries.outputs.ghcr_image }}"
 
           GH_API="https://api.github.com"
           AUTH_HEADER="Authorization: Bearer ${GH_TOKEN}"
@@ -137,7 +143,7 @@ jobs:
           # Always compute "selected" versions/digest for this run
           BASE_DIGEST="$(crane digest "$BASE")"
 
-          # Determine periphery x.y.z tag that matches BASE (latest) digest
+          # Determine periphery x.y.z tag that matches the selected BASE digest
           BASE_CFG="$(crane config "$BASE")"
 
           # Try common version labels from the base image
@@ -155,8 +161,7 @@ jobs:
 
             # Prefer newest first by version sort
             if [ "${#tags[@]}" -gt 0 ]; then
-              IFS=$'\n' tags_sorted=($(printf '%s\n' "${tags[@]}" | sort -V -r))
-              unset IFS
+              mapfile -t tags_sorted < <(printf '%s\n' "${tags[@]}" | sort -V -r)
 
               for t in "${tags_sorted[@]}"; do
                 d="$(crane digest "ghcr.io/moghtech/komodo-periphery:${t}")"
@@ -173,7 +178,16 @@ jobs:
             exit 1
           fi
 
-          echo "periphery_tag=$PERIPHERY_TAG" >> "$GITHUB_OUTPUT"
+          IFS='.' read -r PERIPHERY_MAJOR PERIPHERY_MINOR _ <<< "$PERIPHERY_TAG"
+          PERIPHERY_MAJOR_TAG="${PERIPHERY_MAJOR}"
+          PERIPHERY_MINOR_TAG="${PERIPHERY_MAJOR}.${PERIPHERY_MINOR}"
+          CURRENT_IMAGE="${IMAGE}:${PERIPHERY_MAJOR_TAG}"
+
+          {
+            echo "periphery_tag=$PERIPHERY_TAG"
+            echo "periphery_major_tag=$PERIPHERY_MAJOR_TAG"
+            echo "periphery_minor_tag=$PERIPHERY_MINOR_TAG"
+          } >> "$GITHUB_OUTPUT"
 
           SOPS_TAG="$(curl -fsSL -H "$AUTH_HEADER" -H "Accept: application/vnd.github+json"             "${GH_API}/repos/getsops/sops/releases/latest" | jq -r '.tag_name')"
           AGE_TAG="$(curl -fsSL -H "$AUTH_HEADER" -H "Accept: application/vnd.github+json"             "${GH_API}/repos/FiloSottile/age/releases/latest" | jq -r '.tag_name')"
@@ -184,28 +198,35 @@ jobs:
           SOPS_RELEASE_URL="https://github.com/getsops/sops/releases/tag/${SOPS_TAG}"
           AGE_RELEASE_URL="https://github.com/FiloSottile/age/releases/tag/${AGE_TAG}"
 
-          echo "base_digest=$BASE_DIGEST" >> "$GITHUB_OUTPUT"
-          echo "sops_version=$SOPS_VERSION" >> "$GITHUB_OUTPUT"
-          echo "age_version=$AGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "sops_release_url=$SOPS_RELEASE_URL" >> "$GITHUB_OUTPUT"
-          echo "age_release_url=$AGE_RELEASE_URL" >> "$GITHUB_OUTPUT"
+          {
+            echo "base_digest=$BASE_DIGEST"
+            echo "sops_version=$SOPS_VERSION"
+            echo "age_version=$AGE_VERSION"
+            echo "sops_release_url=$SOPS_RELEASE_URL"
+            echo "age_release_url=$AGE_RELEASE_URL"
+          } >> "$GITHUB_OUTPUT"
 
           # Read "current" versions/digest from the published image (if it exists)
           CURRENT_BASE_DIGEST=""
+          CURRENT_BASE_VERSION=""
           CURRENT_SOPS_VERSION=""
           CURRENT_AGE_VERSION=""
 
-          if crane manifest "$IMAGE" >/dev/null 2>&1; then
-            cfg="$(crane config "$IMAGE")"
+          if crane manifest "$CURRENT_IMAGE" >/dev/null 2>&1; then
+            cfg="$(crane config "$CURRENT_IMAGE")"
             CURRENT_BASE_DIGEST="$(echo "$cfg" | jq -r '.config.Labels["org.opencontainers.image.base.digest"] // ""')"
+            CURRENT_BASE_VERSION="$(echo "$cfg" | jq -r '.config.Labels["org.opencontainers.image.base.version"] // .config.Labels["org.opencontainers.image.base.tag"] // ""')"
             CURRENT_SOPS_VERSION="$(echo "$cfg" | jq -r '.config.Labels["org.opencontainers.image.sops.version"] // ""')"
             CURRENT_AGE_VERSION="$(echo "$cfg" | jq -r '.config.Labels["org.opencontainers.image.age.version"] // ""')"
           fi
 
           # Keep these as outputs (handy for debugging / future reuse)
-          echo "current_base_digest=$CURRENT_BASE_DIGEST" >> "$GITHUB_OUTPUT"
-          echo "current_sops_version=$CURRENT_SOPS_VERSION" >> "$GITHUB_OUTPUT"
-          echo "current_age_version=$CURRENT_AGE_VERSION" >> "$GITHUB_OUTPUT"
+          {
+            echo "current_base_digest=$CURRENT_BASE_DIGEST"
+            echo "current_base_version=$CURRENT_BASE_VERSION"
+            echo "current_sops_version=$CURRENT_SOPS_VERSION"
+            echo "current_age_version=$CURRENT_AGE_VERSION"
+          } >> "$GITHUB_OUTPUT"
 
           # Determine forced build conditions
           FORCED="false"
@@ -255,17 +276,17 @@ jobs:
 
           if [ -z "$CURRENT_BASE_DIGEST" ] || [ "$CURRENT_BASE_DIGEST" != "$BASE_DIGEST" ]; then
             CHANGED="true"
-            reasons+=("komodo-periphery base changed: ${CURRENT_BASE_DIGEST:-<none>} -> ${BASE_DIGEST}")
+            reasons+=("komodo-periphery base changed: ${CURRENT_BASE_DIGEST:-(none)} -> ${BASE_DIGEST}")
           fi
 
           if [ "$CURRENT_SOPS_VERSION" != "$SOPS_VERSION" ]; then
             CHANGED="true"
-            reasons+=("SOPS updated: ${CURRENT_SOPS_VERSION:-<none>} -> ${SOPS_VERSION} ([release notes](${SOPS_RELEASE_URL}))")
+            reasons+=("SOPS updated: ${CURRENT_SOPS_VERSION:-(none)} -> ${SOPS_VERSION} ([release notes](${SOPS_RELEASE_URL}))")
           fi
 
           if [ "$CURRENT_AGE_VERSION" != "$AGE_VERSION" ]; then
             CHANGED="true"
-            reasons+=("age updated: ${CURRENT_AGE_VERSION:-<none>} -> ${AGE_VERSION} ([release notes](${AGE_RELEASE_URL}))")
+            reasons+=("age updated: ${CURRENT_AGE_VERSION:-(none)} -> ${AGE_VERSION} ([release notes](${AGE_RELEASE_URL}))")
           fi
 
           # Final decision
@@ -283,16 +304,19 @@ jobs:
             printf '%s\n' "${reasons[@]}" | sed 's/^/- /'
             echo ""
             echo "### Selected versions (this run)"
+            echo "- target image: ${IMAGE}"
+            echo "- komodo-periphery base channel: ${BASE}"
             echo "- komodo-periphery digest: ${BASE_DIGEST}"
             echo "- komodo-periphery tag: ${PERIPHERY_TAG}"
+            echo "- published tags: ${PERIPHERY_MAJOR_TAG}, ${PERIPHERY_MINOR_TAG}, ${PERIPHERY_TAG}"
             echo "- SOPS: ${SOPS_VERSION} (${SOPS_RELEASE_URL})"
             echo "- age: ${AGE_VERSION} (${AGE_RELEASE_URL})"
             echo ""
             echo "### Current versions (published image)"
-            echo "- komodo-periphery digest: ${CURRENT_BASE_DIGEST:-<none>}"
-            echo "- komodo-periphery tag: ${PERIPHERY_TAG}"
-            echo "- SOPS: ${CURRENT_SOPS_VERSION:-<none>}"
-            echo "- age: ${CURRENT_AGE_VERSION:-<none>}"
+            echo "- komodo-periphery digest: ${CURRENT_BASE_DIGEST:-(none)}"
+            echo "- komodo-periphery tag: ${CURRENT_BASE_VERSION:-(none)}"
+            echo "- SOPS: ${CURRENT_SOPS_VERSION:-(none)}"
+            echo "- age: ${CURRENT_AGE_VERSION:-(none)}"
             echo ""
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
@@ -303,9 +327,10 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository_owner }}/komodo-periphery-sops-age
+          images: ${{ steps.registries.outputs.ghcr_image }}
           tags: |
-            type=raw,value=latest
+            type=raw,value=${{ steps.decide.outputs.periphery_major_tag }}
+            type=raw,value=${{ steps.decide.outputs.periphery_minor_tag }}
             type=raw,value=${{ steps.decide.outputs.periphery_tag }}
 
 
@@ -320,7 +345,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: |
             ${{ steps.meta.outputs.labels }}
-            org.opencontainers.image.base.name=ghcr.io/moghtech/komodo-periphery:latest
+            org.opencontainers.image.version=${{ steps.decide.outputs.periphery_tag }}
+            org.opencontainers.image.base.name=ghcr.io/moghtech/komodo-periphery:2
             org.opencontainers.image.base.tag=${{ steps.decide.outputs.periphery_tag }}
             org.opencontainers.image.base.digest=${{ steps.decide.outputs.base_digest }}
             org.opencontainers.image.base.version=${{ steps.decide.outputs.periphery_tag }}
@@ -348,14 +374,16 @@ jobs:
         shell: bash
         env:
           DOCKERHUB_IMAGE: ${{ steps.registries.outputs.dockerhub_image }}
+          PERIPHERY_MAJOR_TAG: ${{ steps.decide.outputs.periphery_major_tag }}
+          PERIPHERY_MINOR_TAG: ${{ steps.decide.outputs.periphery_minor_tag }}
           PERIPHERY_TAG: ${{ steps.decide.outputs.periphery_tag }}
         run: |
           set -euo pipefail
 
-          src_base="ghcr.io/${{ github.repository_owner }}/komodo-periphery-sops-age"
+          src_base="${{ steps.registries.outputs.ghcr_image }}"
           dst_base="${DOCKERHUB_IMAGE}"
 
-          for tag in latest "${PERIPHERY_TAG}"; do
+          for tag in "${PERIPHERY_MAJOR_TAG}" "${PERIPHERY_MINOR_TAG}" "${PERIPHERY_TAG}"; do
             crane copy "${src_base}:${tag}" "${dst_base}:${tag}"
           done
 
@@ -367,22 +395,24 @@ jobs:
             printf '%s\n' "${{ steps.decide.outputs.reasons_md }}"
             printf '\n### Image\n'
             if [ "${{ github.event_name }}" = "pull_request" ]; then
-              printf -- '- Validation build only. No image was pushed.\n'
+              printf -- "- Validation build only. No image was pushed.\n"
             else
-              printf -- '- `ghcr.io/${{ github.repository_owner }}/komodo-periphery-sops-age:latest`\n'
-              printf -- '- `ghcr.io/${{ github.repository_owner }}/komodo-periphery-sops-age:${{ steps.decide.outputs.periphery_tag }}`\n'
+              printf -- "- \`${{ steps.registries.outputs.ghcr_image }}:${{ steps.decide.outputs.periphery_major_tag }}\`\n"
+              printf -- "- \`${{ steps.registries.outputs.ghcr_image }}:${{ steps.decide.outputs.periphery_minor_tag }}\`\n"
+              printf -- "- \`${{ steps.registries.outputs.ghcr_image }}:${{ steps.decide.outputs.periphery_tag }}\`\n"
             fi
             printf '\n### Docker Hub Mirror\n'
             if [ "${{ github.event_name }}" = "pull_request" ]; then
-              printf -- '- Skipped for pull request validation.\n'
+              printf -- "- Skipped for pull request validation.\n"
             elif [ "${{ steps.registries.outputs.dockerhub_enabled }}" != "true" ]; then
-              printf -- '- Skipped: set `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository secrets to enable Docker Hub publishing.\n'
+              printf -- "- Skipped: set \`DOCKERHUB_USERNAME\` and \`DOCKERHUB_TOKEN\` repository secrets to enable Docker Hub publishing.\n"
             elif [ "${{ steps.decide.outputs.do_build }}" != "true" ]; then
-              printf -- '- No image build was required, so Docker Hub was not updated.\n'
+              printf -- "- No image build was required, so Docker Hub was not updated.\n"
             elif [ "${{ steps.dockerhub_mirror.outcome }}" = "success" ]; then
-              printf -- '- `smoochy84/komodo-periphery-sops-age:latest`\n'
-              printf -- '- `smoochy84/komodo-periphery-sops-age:${{ steps.decide.outputs.periphery_tag }}`\n'
+              printf -- "- \`${{ steps.registries.outputs.dockerhub_image }}:${{ steps.decide.outputs.periphery_major_tag }}\`\n"
+              printf -- "- \`${{ steps.registries.outputs.dockerhub_image }}:${{ steps.decide.outputs.periphery_minor_tag }}\`\n"
+              printf -- "- \`${{ steps.registries.outputs.dockerhub_image }}:${{ steps.decide.outputs.periphery_tag }}\`\n"
             else
-              printf -- '- Mirror was attempted but did not complete successfully.\n'
+              printf -- "- Mirror was attempted but did not complete successfully.\n"
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync_dockerhub_description.yml
+++ b/.github/workflows/sync_dockerhub_description.yml
@@ -24,15 +24,19 @@ jobs:
         id: dockerhub
         shell: bash
         env:
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKERHUB_REPOSITORY: ${{ vars.DOCKERHUB_REPOSITORY }}
         run: |
           set -euo pipefail
 
           if [ -n "${DOCKERHUB_USERNAME:-}" ] && [ -n "${DOCKERHUB_TOKEN:-}" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "repository=${DOCKERHUB_REPOSITORY:-${DOCKERHUB_USERNAME}/${REPOSITORY_NAME}}" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "repository=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Update Docker Hub description
@@ -41,7 +45,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: smoochy84/komodo-periphery-sops-age
+          repository: ${{ steps.dockerhub.outputs.repository }}
           short-description: Komodo Periphery image with SOPS and age, rebuilt on upstream changes
           readme-filepath: ./README.dockerhub.md
           enable-url-completion: true
@@ -51,7 +55,7 @@ jobs:
         shell: bash
         run: |
           if [ "${{ steps.dockerhub.outputs.enabled }}" = "true" ]; then
-            printf 'Docker Hub description sync completed for `smoochy84/komodo-periphery-sops-age`.\n' >> "$GITHUB_STEP_SUMMARY"
+            printf "Docker Hub description sync completed for \`${{ steps.dockerhub.outputs.repository }}\`.\n" >> "$GITHUB_STEP_SUMMARY"
           else
-            printf 'Docker Hub description sync skipped. Set `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository secrets to enable it.\n' >> "$GITHUB_STEP_SUMMARY"
+            printf "Docker Hub description sync skipped. Set \`DOCKERHUB_USERNAME\` and \`DOCKERHUB_TOKEN\` repository secrets to enable it.\n" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM ghcr.io/moghtech/komodo-periphery:latest
+FROM ghcr.io/moghtech/komodo-periphery:2
 
 USER root
 
@@ -42,7 +42,7 @@ RUN set -eux; \
     sops --version --check-for-updates; \
     age --version
 
-LABEL org.opencontainers.image.base.name="ghcr.io/moghtech/komodo-periphery:latest"
+LABEL org.opencontainers.image.base.name="ghcr.io/moghtech/komodo-periphery:2"
 LABEL org.opencontainers.image.base.version="${BASE_VERSION}"
 LABEL org.opencontainers.image.base.digest="${BASE_DIGEST}"
 LABEL org.opencontainers.image.sops.version="${SOPS_VERSION}"

--- a/README.dockerhub.md
+++ b/README.dockerhub.md
@@ -7,13 +7,12 @@
 [![Buy me uptime](https://img.shields.io/badge/Buy%20me%20uptime%20%F0%9F%96%A5%EF%B8%8F-smoochy84-E9C46A?logo=buymeacoffee&logoColor=000000)](https://www.buymeacoffee.com/smoochy84)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-smoochy-7CC6FE?logo=ko-fi&logoColor=000000)](https://ko-fi.com/smoochy)
 
-Komodo Periphery image with `sops`, `age`, and `age-keygen` preinstalled,
-rebuilt automatically when upstream components change.
+Komodo Periphery image with `sops`, `age`, and `age-keygen` preinstalled, rebuilt automatically when upstream components change.
 
 ## Quick pull
 
 ```bash
-docker pull smoochy84/komodo-periphery-sops-age:latest
+docker pull smoochy84/komodo-periphery-sops-age:2
 ```
 
 ## What you get
@@ -25,25 +24,30 @@ docker pull smoochy84/komodo-periphery-sops-age:latest
 
 ## Tags
 
-- `latest`
-- `<x.y.z>` matching the upstream Komodo Periphery release
+- `<x>` floating major tag, for example `2`
+- `<x.y>` floating major/minor tag, for example `2.0`
+- `<x.y.z>` exact upstream Komodo Periphery release, for example `2.0.0`
+
+The exact release tag is derived from the digest currently served by `ghcr.io/moghtech/komodo-periphery:2`, so the current published v2 tag set is `2`, `2.0`, and `2.0.0`.
+
+If you are upgrading an existing Komodo v1 deployment to v2, follow the
+official Komodo upgrade guide:
+
+<https://komo.do/docs/releases/v2.0.0#upgrading-to-komodo-v2>
 
 ## Why this image
 
 - Avoid maintaining a separate bootstrap image for secret tooling
 - Keep encrypted deployment workflows ready out of the box
 - Track upstream changes automatically
-- Use reproducible version tags for pinned deployments
+- Use floating SemVer channels or exact version tags for pinned deployments
 
 ## Full documentation
 
-See the GitHub repository for install details, workflow behavior, and example
-usage:
+See the GitHub repository for install details, workflow behavior, and example usage:
 
 <https://github.com/smoochy/komodo-periphery-sops-age>
 
 ## Support
 
-If this image saves you time or helps your setup, you can support ongoing
-maintenance for a project I maintain in my spare time via Ko-fi or Buy Me a
-Coffee.
+If this image saves you time or helps your setup, you can support ongoing maintenance for a project I maintain in my spare time via Ko-fi or Buy Me a Coffee.

--- a/README.md
+++ b/README.md
@@ -8,60 +8,55 @@
 
 > A custom [Komodo](https://github.com/moghtech/komodo) Periphery image with [SOPS](https://github.com/getsops/sops) and [age](https://github.com/FiloSottile/age), published to GHCR with a public Docker Hub mirror and rebuilt automatically when upstream components change.
 
-This repository publishes a Docker image based on
-`ghcr.io/moghtech/komodo-periphery:latest` with `sops`, `age`, and
-`age-keygen` preinstalled. It is intended for self-hosted environments that
-want a ready-to-use Periphery image for encrypted secrets and configuration
-handling without maintaining a custom build pipeline from scratch.
+This repository publishes a Docker image based on `ghcr.io/moghtech/komodo-periphery:2` with `sops`, `age`, and `age-keygen` preinstalled. It is intended for self-hosted environments that want a ready-to-use Periphery image for encrypted secrets and configuration handling without maintaining a custom build pipeline from scratch.
 
 Registries:
 
 - GHCR (canonical): `ghcr.io/smoochy/komodo-periphery-sops-age`
 - Docker Hub (public mirror): `smoochy84/komodo-periphery-sops-age`
 
-If this project helps your deployment workflow, you can support ongoing
-maintenance for a project I maintain in my spare time via Ko-fi or Buy Me a
-Coffee.
+If this project helps your deployment workflow, you can support ongoing maintenance for a project I maintain in my spare time via Ko-fi or Buy Me a Coffee.
 
 ## Table of Contents
 
-- [Background](#background)
-- [What This Repository Does](#what-this-repository-does)
-- [When Builds Run](#when-builds-run)
-- [Dockerfile](#dockerfile)
-- [GitHub Actions Workflow](#github-actions-workflow)
-- [Job Summary](#job-summary)
-- [Image Metadata](#image-metadata)
-- [Image Tags](#image-tags)
-- [Install](#install)
-- [Usage](#usage)
-- [Transparency](#transparency)
-- [Security](#security)
-- [Maintainers](#maintainers)
-- [Contributing](#contributing)
-- [License](#license)
+- [komodo-periphery-sops-age](#komodo-periphery-sops-age)
+  - [Table of Contents](#table-of-contents)
+  - [Background](#background)
+  - [What This Repository Does](#what-this-repository-does)
+  - [When Builds Run](#when-builds-run)
+  - [Dockerfile](#dockerfile)
+  - [GitHub Actions Workflow](#github-actions-workflow)
+  - [Job Summary](#job-summary)
+  - [Image Metadata](#image-metadata)
+  - [Image Tags](#image-tags)
+  - [Install](#install)
+  - [Usage](#usage)
+  - [Transparency](#transparency)
+  - [Security](#security)
+  - [Maintainers](#maintainers)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 ## Background
 
-Komodo Periphery does not include every tool needed for encrypted
-configuration workflows out of the box. This project provides a maintained
-image variant with SOPS and age preinstalled so those workflows can be used
-directly.
+Komodo Periphery does not include every tool needed for encrypted configuration workflows out of the box. This project provides a maintained image variant with SOPS and age preinstalled so those workflows can be used directly.
 
 ## What This Repository Does
 
-- Builds a custom Docker image based on `ghcr.io/moghtech/komodo-periphery:latest`
+- Builds a custom Docker image based on `ghcr.io/moghtech/komodo-periphery:2`
 - Adds:
   - `sops`
   - `age`
   - `age-keygen`
 - Publishes the image to:
   - GHCR (canonical):
-    - `ghcr.io/smoochy/komodo-periphery-sops-age:latest`
-    - `ghcr.io/smoochy/komodo-periphery-sops-age:<komodo-version>`
+    - `ghcr.io/smoochy/komodo-periphery-sops-age:<major>`
+    - `ghcr.io/smoochy/komodo-periphery-sops-age:<major.minor>`
+    - `ghcr.io/smoochy/komodo-periphery-sops-age:<major.minor.patch>`
   - Docker Hub (public mirror):
-    - `smoochy84/komodo-periphery-sops-age:latest`
-    - `smoochy84/komodo-periphery-sops-age:<komodo-version>`
+    - `smoochy84/komodo-periphery-sops-age:<major>`
+    - `smoochy84/komodo-periphery-sops-age:<major.minor>`
+    - `smoochy84/komodo-periphery-sops-age:<major.minor.patch>`
 - Tracks upstream updates and rebuilds only when needed
 
 ## When Builds Run
@@ -76,8 +71,7 @@ The workflow is triggered in three ways:
    This prevents rebuilds for documentation-only changes such as `README.md`.
 
 2. Scheduled run:
-   - Runs a daily check for upstream changes such as the base digest, SOPS
-     release, and age release
+   - Runs a daily check for upstream changes such as the base digest, SOPS release, and age release
    - Builds only if something changed
 
 3. Manual run with `workflow_dispatch`:
@@ -87,7 +81,7 @@ The workflow is triggered in three ways:
 
 The `Dockerfile`:
 
-- Uses `ghcr.io/moghtech/komodo-periphery:latest` as the base image
+- Uses `ghcr.io/moghtech/komodo-periphery:2` as the base image
 - Installs minimal dependencies such as `curl`, `tar`, and CA certificates
 - Downloads and installs:
   - SOPS from `getsops/sops` GitHub releases
@@ -97,8 +91,7 @@ The `Dockerfile`:
   - `linux/arm64`
 - Stores the selected versions as OCI labels
 
-The Dockerfile does not decide which versions to install. Version selection is
-done by the workflow and passed in via build args.
+The Dockerfile does not decide which versions to install. Version selection is done by the workflow and passed in via build args.
 
 ## GitHub Actions Workflow
 
@@ -111,12 +104,15 @@ done by the workflow and passed in via build args.
    - komodo-periphery base digest
    - SOPS latest release version
    - age latest release version
-5. Builds once, pushes to GHCR, and mirrors the published tags to Docker Hub
-   when Docker Hub secrets are configured.
+5. Builds once, pushes to GHCR, and mirrors the published tags to Docker Hub when Docker Hub secrets are configured.
 6. Publishes only when:
    - a push-triggered run happens
    - an upstream change is detected
    - a manual run is forced
+7. Publishes three SemVer tags for the selected Komodo release:
+   - the floating major tag, for example `2`
+   - the floating major/minor tag, for example `2.0`
+   - the exact release tag, for example `2.0.0`
 
 ## Job Summary
 
@@ -133,8 +129,7 @@ This makes it obvious why a new image was published and what changed.
 
 ## Image Metadata
 
-Each published image includes OCI labels used for traceability and change
-detection, for example:
+Each published image includes OCI labels used for traceability and change detection, for example:
 
 - `org.opencontainers.image.base.tag`
 - `org.opencontainers.image.base.digest`
@@ -145,23 +140,35 @@ detection, for example:
 
 This image is published with:
 
-- `latest`: always points to the newest build
-- `<x.y.z>`: matches the upstream Komodo Periphery version tag and is useful
-  for reproducible deployments pinned to a specific Komodo release
+- `<x>`: tracks the current upstream Komodo major line, for example `2`
+- `<x.y>`: tracks the current upstream Komodo minor line, for example `2.0`
+- `<x.y.z>`: matches the exact upstream Komodo Periphery release and is useful for reproducible deployments pinned to a specific Komodo release
+
+The exact `<x.y.z>` tag is resolved from the digest currently served by `ghcr.io/moghtech/komodo-periphery:2`. For the current upstream v2 release, that means the custom image publishes `2`, `2.0`, and `2.0.0`.
 
 ## Install
 
 Pull the published image from GHCR (canonical) or Docker Hub (public mirror):
 
 ```bash
-docker pull ghcr.io/smoochy/komodo-periphery-sops-age:latest
+docker pull ghcr.io/smoochy/komodo-periphery-sops-age:2
+```
+
+If you want to follow the Komodo v2 line without pinning to one exact patch release, use the floating major tag:
+
+```bash
+docker pull smoochy84/komodo-periphery-sops-age:2
 ```
 
 ```bash
-docker pull smoochy84/komodo-periphery-sops-age:latest
+docker pull ghcr.io/smoochy/komodo-periphery-sops-age:2.0
 ```
 
-If you need a specific Komodo release, pull the matching version tag instead:
+```bash
+docker pull smoochy84/komodo-periphery-sops-age:2.0
+```
+
+If you need a specific Komodo release, pull the matching exact version tag instead:
 
 ```bash
 docker pull ghcr.io/smoochy/komodo-periphery-sops-age:<x.y.z>
@@ -171,6 +178,8 @@ docker pull ghcr.io/smoochy/komodo-periphery-sops-age:<x.y.z>
 docker pull smoochy84/komodo-periphery-sops-age:<x.y.z>
 ```
 
+If you are upgrading an existing Komodo v1 deployment to v2, [follow the official Komodo upgrade guide](https://komo.do/docs/releases/v2.0.0#upgrading-to-komodo-v2).
+
 ## Usage
 
 Example `docker-compose.yml`:
@@ -178,7 +187,7 @@ Example `docker-compose.yml`:
 ```yaml
 services:
   periphery:
-    image: ghcr.io/smoochy/komodo-periphery-sops-age:latest
+    image: ghcr.io/smoochy/komodo-periphery-sops-age:2
 ```
 
 or
@@ -186,17 +195,14 @@ or
 ```yaml
 services:
   periphery:
-    image: ghcr.io/smoochy/komodo-periphery-sops-age:1.19.5
+    image: ghcr.io/smoochy/komodo-periphery-sops-age:2.0.0
 ```
 
-The same tags are mirrored to Docker Hub at
-[smoochy84/komodo-periphery-sops-age](https://hub.docker.com/r/smoochy84/komodo-periphery-sops-age).
+The same tags are mirrored to Docker Hub at [smoochy84/komodo-periphery-sops-age](https://hub.docker.com/r/smoochy84/komodo-periphery-sops-age).
 
 ## Transparency
 
-The code, documentation, and related project materials in this repository were
-created and refined with AI assistance. All generated output was reviewed and
-adapted before publication.
+The code, documentation, and related project materials in this repository were created and refined with AI assistance. All generated output was reviewed and adapted before publication.
 
 ## Security
 
@@ -214,8 +220,7 @@ adapted before publication.
 
 ## Contributing
 
-Issues and pull requests are welcome. Keep Dockerfile, workflow, and README
-changes aligned so the published image behavior remains easy to audit.
+Issues and pull requests are welcome. Keep Dockerfile, workflow, and README changes aligned so the published image behavior remains easy to audit.
 
 ## License
 


### PR DESCRIPTION
- Upgraded periphery to v2
- Followed official semver
- `:latest` tag will stay on version 1.19.5